### PR TITLE
Improve logging for hooks

### DIFF
--- a/src/Runner.Worker/Container/ContainerHooks/ContainerHookManager.cs
+++ b/src/Runner.Worker/Container/ContainerHooks/ContainerHookManager.cs
@@ -193,20 +193,20 @@ namespace GitHub.Runner.Worker.Container.ContainerHooks
             await handler.RunAsync(stage);
             if (handler.ExecutionContext.Result == TaskResult.Failed)
             {
-                throw new Exception($"Hook command '{input.Command}' failed"); // TODO: better exception
+                throw new Exception($"The hook script at '{HookIndexPath}' running command '{input.Command}' did not execute successfully."); // TODO: better exception
             }
-            Trace.Info($"Hook command '{input.Command}' successfully executed");
+            Trace.Info($"The hook script at '{HookIndexPath}' running command '{input.Command}' executed successfully.");
 
             HookResponse response = null;
             if (!string.IsNullOrEmpty(input.ResponseFile) && File.Exists(input.ResponseFile))
             {
                 response = IOUtil.LoadObject<HookResponse>(input.ResponseFile);
                 IOUtil.DeleteFile(input.ResponseFile);
-                Trace.Info("Response file successfully processed and deleted");
+                Trace.Info($"Response file for the hook script at '{HookIndexPath}' running command '{input.Command}' successfully processed and deleted.");
             }
             else
             {
-                Trace.Info($"Response file not found for command '{input.Command}'");
+                Trace.Info($"Response file for the hook script at '{HookIndexPath}' running command '{input.Command}' not found.");
             }
             return response;
         }

--- a/src/Runner.Worker/Container/ContainerHooks/ContainerHookManager.cs
+++ b/src/Runner.Worker/Container/ContainerHooks/ContainerHookManager.cs
@@ -193,9 +193,10 @@ namespace GitHub.Runner.Worker.Container.ContainerHooks
             await handler.RunAsync(stage);
             if (handler.ExecutionContext.Result == TaskResult.Failed)
             {
-                throw new Exception("Hook failed"); // TODO: better exception
+                throw new Exception($"Hook command {input.Command} failed"); // TODO: better exception
             }
-
+            Trace.Info($"Hook command {input.Command} successfully executed");
+            
             HookResponse response = null;
             if (!string.IsNullOrEmpty(input.ResponseFile) && File.Exists(input.ResponseFile))
             {

--- a/src/Runner.Worker/Container/ContainerHooks/ContainerHookManager.cs
+++ b/src/Runner.Worker/Container/ContainerHooks/ContainerHookManager.cs
@@ -193,10 +193,10 @@ namespace GitHub.Runner.Worker.Container.ContainerHooks
             await handler.RunAsync(stage);
             if (handler.ExecutionContext.Result == TaskResult.Failed)
             {
-                throw new Exception($"Hook command {input.Command} failed"); // TODO: better exception
+                throw new Exception($"Hook command '{input.Command}' failed"); // TODO: better exception
             }
-            Trace.Info($"Hook command {input.Command} successfully executed");
-            
+            Trace.Info($"Hook command '{input.Command}' successfully executed");
+
             HookResponse response = null;
             if (!string.IsNullOrEmpty(input.ResponseFile) && File.Exists(input.ResponseFile))
             {


### PR DESCRIPTION
Closes #76, #79

What we currently log?
   - Hook command 'hook_name' executed successfully / Hook command 'hook_name' failed
   - Response file successfully processed and deleted / Response file not found for command 'hook_name'

What should we log?
   - Hook state?
   - More ideas?
